### PR TITLE
Fix populate sh - checkout php source using git instead of svn

### DIFF
--- a/scripts/populatedocs.sh
+++ b/scripts/populatedocs.sh
@@ -17,6 +17,7 @@
 #
 
 SVNBIN="/usr/bin/env svn"
+GITBIN="/usr/bin/env git"
 pushd .
 
 cd `dirname $0`/..
@@ -42,10 +43,10 @@ fi
 echo "Checking out php-src..."
 if [ -d ${SRCDIR} ]
 then
-  (cd ${SRCDIR} && ${SVNBIN} up)
+  (cd ${SRCDIR} && ${GITBIN} pull)
 else
   BDIR=`basename ${SRCDIR}`
-  ${SVNBIN} co http://svn.php.net/repository/php/php-src/trunk ${BDIR}
+  ${GITBIN} clone https://github.com/php/php-src ${BDIR}
 fi
 
 echo -n "Reverting directory:"


### PR DESCRIPTION
Trying to use current `scripts/populate.sh`, I got this message:

``` shell
Checking out php-src...
svn: E170000: URL 'http://svn.php.net/repository/php/php-src/trunk' doesn't exist
```

This Pull Request fix that, making the use of git to checkout the source from GitHub repo.
