### PR TITLE
Update translation docs

### DIFF
--- a/tutorial/editing.md
+++ b/tutorial/editing.md
@@ -1,7 +1,7 @@
 # Editing manual sources
 
 ## Introduction
-Before making any changes to the manual - either English version ore
+Before making any changes to the manual - either English version or
 translation, make sure you read [style guidelines](style.php)!
 
 ## Editing existing documentation

--- a/tutorial/faq.md
+++ b/tutorial/faq.md
@@ -24,6 +24,7 @@ Note: Usually the problem is a major XML syntax issue.
 
 ## Is there an online editor?
 Yes, just go to [edit.php.net][editor]. Our wiki contains an [overview of the editor and how to use it][editor-tutorial].
+PHP account is required.
 
 ## How do I add a link to a method?
 Use `<methodname>Class::method</methodname>`. Note that the case does not matter when adding a link.

--- a/tutorial/intro.md
+++ b/tutorial/intro.md
@@ -9,7 +9,7 @@ This guide uses some terminology that you have to know. Don't worry, it's easy:
 - **translator** - person who translates the English manual into another language
 - **{LANG}** - replace it with your two-letter country code, (e.g. when referring
   to a mailinglist, `doc-{LANG}@lists.php.net`). Note: Brazilian Portuguese differs
-  from the rest and it's called *pt_BR* for the SVN module and *pt-br* for the
+  from the rest and it's called *pt_br* for the git repository and *pt-br* for the
   mailing list suffix.
 
 ## Table of Contents

--- a/tutorial/joining.md
+++ b/tutorial/joining.md
@@ -15,18 +15,15 @@ You should send your message to the `phpdoc@lists.php.net` mailing list.
 You should send your message to the appropriate `doc-{LANG}@lists.php.net` mailing list.
 
 ## Create a doc patch or three
-This step is required to show us that you are a real human, you want to do
-some work and in general know how to do this.
+This step is required to show us that you are a real human,
+you want to do some work and in general, know how to do this.
 
-The simplest way to get started is by using the [Online Documentation Editor][editor].
-which allows you to login via your Facebook/Twitter/Google account and edit the documentation.
-Your patches will be then reviewed and accepted by someone with SVN access.
+The simplest way to get started is by sending patches on GitHub.
+Documentation and translation repositories hosted on GitHub by URL `https://github.com/php/doc-{LANG}`
 
-Our wiki contains an [overview of the editor and how to use it][editor-tutorial].
-
-## Obtaining SVN access
-If you plan to contribute to the manual regularly, and want to do this more efficiently,
-you probably would like to use SVN directly. This requires a PHP.net account.
+## Obtaining GitHub access
+If you plan to contribute to the manual regularly, and want to do this more efficiently, you probably would like to use Git directly.
+It requires a [PHP][github-php] membership on GitHub.
 
 To request one, please fill in [this form][request-account].
 
@@ -36,5 +33,4 @@ Basically, tell us what you have done, to prove that you really need this accoun
 The next chapter will explain how to get the manual sources and how are they [structured](structure.php).
 
 [request-account]: http://php.net/git-php.php
-[editor]: https://edit.php.net
-[editor-tutorial]: https://wiki.php.net/doc/editor
+[github-php]: https://github.com/php/

--- a/tutorial/translating.md
+++ b/tutorial/translating.md
@@ -43,12 +43,26 @@ Otherwise, it needs to be synced.
 Let's assume that you want to update the translation of `in_array()`.
 There are two simple ways to see which files require updating and what has to be changed to sync with the English version:
 using [Online Editor](https://edit.php.net) (required PHP account)
-or [doc.php.net tools](http://doc.php.gpb.moe/tools/revcheck/). The second way is described below.
+or using command line. The second way is described below.
 
-Choose your language from the top and then use the "Outdated files" tool.
-You will get a list of outdated files, their revision, as well as the actual English revision.
+Clone the [doc-base](https://github.com/php/doc-base) repository one level with 
+[doc-en](https://github.com/php/doc-en) and your language repositories, so that the structure is as follows:
 
-To show changes run the following command in your terminal:
+```
+├── doc-base/
+├── en/
+└── {LANG}/
+```
+
+Then run the next script and open `revcheck.html` in any browser: 
+
+```
+php doc-base/scripts/revcheck.php {LANG} > revcheck.html
+```
+
+In "Outdated Files" section you can see actual English revision and yours.
+
+To get diff between revisions, run the script:
 
 ```
 git --no-pager diff 8b5940cadeb4f1c8492f4a7f70743a2be807cf39 68a9c82e06906a5c00e0199307d87dd3739f719b reference/array/functions/in-array.xml

--- a/tutorial/translating.md
+++ b/tutorial/translating.md
@@ -41,9 +41,23 @@ Otherwise, it needs to be synced.
 
 ## Updating translation of existing file
 Let's assume that you want to update the translation of `in_array()`.
-There are two simple ways to see which files require updating and what has to be changed to sync with the English version:
-using [Online Editor](https://edit.php.net) (required PHP account)
-or using command line. The second way is described below.
+There are three simple ways to see which files require updating and what has to be changed to sync with the English version:
+using [Online Editor](https://edit.php.net) (required PHP account),
+[doc.php.net tools](http://doc.php.net) or command line.
+
+The second and third ways are described below.
+
+### Using the doc.php.net tool
+
+Choose your language from the right sidebar and then use the "Outdated files" tool.
+Filter files by directory or username (username used here comes from the `Mantainer`
+variable in the header comment described above). Let's assume that the tool marked
+`in-array.xml` as outdated. Click on the filename and you will see
+*diff* - list of changes between two versions of file: your version (current
+number in `EN-Revision` in your translation) and newest version in the English source
+tree.
+
+### Using the command line interface
 
 Clone the [doc-base](https://github.com/php/doc-base) repository one level with 
 [doc-en](https://github.com/php/doc-en) and your language repositories, so that the structure is as follows:
@@ -69,6 +83,8 @@ git --no-pager diff 8b5940cadeb4f1c8492f4a7f70743a2be807cf39 68a9c82e06906a5c00e
 ```
 
 where the first revision is yours, and the second one is the current English revision.
+
+### How to update the translation
 
 The example below should what the diff might look like:
 
@@ -106,7 +122,7 @@ and after changes it should look like this:
 <!-- EN-Revision: 68a9c82e06906a5c00e0199307d87dd3739f719b Maintainer: someone Status: ready -->
 <!-- CREDITS: johnsmith -->
 ```
-The new EN-Revision came from the diff shown above. If you want to add
+The new `EN-Revision` came from the diff shown above. If you want to add
 yourself to a CREDITS tag that already exists, separate
 usernames with a comma, i.e.: `<!-- CREDITS: george, johnsmith -->`.
 

--- a/tutorial/translating.md
+++ b/tutorial/translating.md
@@ -6,10 +6,10 @@ You will also have to follow other steps from the [editing manual sources](editi
 Translating documentation into other languages might look like a complicated
 process, but in fact, it's rather simple.
 
-Every file in SVN has a *revision number*. It is basically the current version of
+Every file in Git has a *revision*. It is basically the current version of
 the specified file. We use revisions to check if a file is synchronized with its
 English counterpart: to find out if the translation is up-to-date. That's why every
-file in your translation requires an EN-Revision comment with the following syntax:
+file in your translation requires an `EN-Revision` comment with the following syntax:
 ```
 <!-- EN-Revision: [some number] Maintainer: [username] Status: ready -->
 ```
@@ -18,83 +18,81 @@ that this translated file is based on. Let's see examples:
 
 ## Translating new file
 Say you want to translate the documentation of the `in_array()` function, which
-doesn't exist in your language yet. Open the file `phpdoc/en/reference/array/in-array.xml`
-and copy the revision number. The English file's header might look like this:
+doesn't exist in your language yet.
+
+If you want to translate the file `/reference/array/functions/in-array.xml`,
+run the following command in cloned `doc-en` git repository and copy the output git hash value: 
+
+```
+git --no-pager log -n 1 --pretty=format:%H -- reference/array/functions/in-array.xml
+68a9c82e06906a5c00e0199307d87dd3739f719b
+```
+
+So our English revision is `68a9c82e06906a5c00e0199307d87dd3739f719b`.
+Let's see how your translated file header should look like if we assume that your username is *johnsmith*:
 ```
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision: 310394 $ -->
+<!-- EN-Revision: 68a9c82e06906a5c00e0199307d87dd3739f719b Maintainer: johnsmith Status: ready -->
 ```
 
-So our revision number is `310394`. Let's see how your translated file header
-should look like if we assume that your SVN username is *johnsmith*:
-```
-<?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 310394 Maintainer: johnsmith Status: ready -->
-<!-- $Revision$ -->
-```
-
-`$Revision$` is an SVN keyword, which will be replaced with the number of current
-revision when you commit your changes. The revision number that you have copied
-from the English file was created this way.
-
-The rule is simple: if your revision number is equal to the revision number of
+The rule is simple: if your revision is equal to the revision of
 the English file you've translated, then your translation is up-to-date.
 Otherwise, it needs to be synced.
 
 ## Updating translation of existing file
-Let's assume that you want to update the translation of `password_needs_rehash()`.
-There are two simple ways to see which files require updating and what has to be
-changed to sync with English version: using [Online Editor](https://edit.php.net)
-or [doc.php.net tools](http://doc.php.net). The second way is described below.
+Let's assume that you want to update the translation of `in_array()`.
+There are two simple ways to see which files require updating and what has to be changed to sync with the English version:
+using [Online Editor](https://edit.php.net) (required PHP account)
+or [doc.php.net tools](http://doc.php.gpb.moe/tools/revcheck/). The second way is described below.
 
-Choose your language from the right sidebar and then use the "Outdated files" tool.
-Filter files by directory or username (username used here comes from the `Mantainer`
-variable in the header comment described above). Let's assume that the tool marked
-`password-needs-rehash.xml` as outdated. Click on the filename and you will see
-*diff* - list of changes between two versions of file: your version (current
-number in EN-Revision in your translation) and newest version in the English source
-tree. The example below should what the diff might look like:
+Choose your language from the top and then use the "Outdated files" tool.
+You will get a list of outdated files, their revision, as well as the actual English revision.
+
+To show changes run the following command in your terminal:
 
 ```
---- phpdoc/en/trunk/reference/password/functions/password-needs-rehash.xml	2013/06/21 12:24:55	330609
-+++ phpdoc/en/trunk/reference/password/functions/password-needs-rehash.xml	2014/03/24 20:23:27	333093
-@@ -12,8 +12,8 @@
-   <methodsynopsis>
-    <type>boolean</type><methodname>password_needs_rehash</methodname>
-    <methodparam><type>string</type><parameter>hash</parameter></methodparam>
--   <methodparam><type>string</type><parameter>algo</parameter></methodparam>
--   <methodparam choice="opt"><type>string</type><parameter>options</parameter></methodparam>
-+   <methodparam><type>integer</type><parameter>algo</parameter></methodparam>
-+   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+git --no-pager diff 8b5940cadeb4f1c8492f4a7f70743a2be807cf39 68a9c82e06906a5c00e0199307d87dd3739f719b reference/array/functions/in-array.xml
+```
+
+where the first revision is yours, and the second one is the current English revision.
+
+The example below should what the diff might look like:
+
+```
+--- a/reference/array/functions/in-array.xml
++++ b/reference/array/functions/in-array.xml
+@@ -14,7 +14,7 @@
+    <methodparam choice="opt"><type>bool</type><parameter>strict</parameter><initializer>&false;</initializer></methodparam>
    </methodsynopsis>
    <para>
-    This function checks to see if the supplied hash implements the algorithm
+-   Searches <parameter>haystack</parameter> for <parameter>needle</parameter> using loose comparison
++   Searches for <parameter>needle</parameter> in <parameter>haystack</parameter> using loose comparison
+    unless <parameter>strict</parameter> is set.
+   </para>
+  </refsect1>
 ```
 
-The first two lines indicate the compared revisions. The first was taken from the
-EN-Revision number and the second is the current version of this file in English.
+As you can see, there is a difference in the function description.
+The line `Searches <parameter>haystack</parameter> for <parameter>needle</parameter> using loose comparison`
+replaced with `Searches for <parameter>needle</parameter> in <parameter>haystack</parameter> using loose comparison`.
 
-As you can see, there is a difference between two lines. The `types` for the
-parameters `options` and `algo` in the synopsis had been changed from `string`,
-to `integer` and `array` respectively. You have to perform these changes in your
-translation to make it up-to-date. Open `phpdoc/{LANG}/reference/password/functions/password-needs-rehash.xml`
-and change those lines to match the English version.
+You have to perform these changes in your translation to make it up-to-date.
+Open `reference/array/functions/in-array.xml` in the translation repository
+and change this line to match the English version.
 
-Then update the EN-Revision number in the header comment. You can also add your
+Then update the `EN-Revision` in the header comment. You can also add your
 credits using the CREDITS tag. Your file header might look like this initially:
 ```
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330609 Maintainer: someone Status: ready -->
-<!-- $Revision: 123456$ -->
+<!-- EN-Revision: 8b5940cadeb4f1c8492f4a7f70743a2be807cf39 Maintainer: someone Status: ready -->
 ```
-and after changes it should looke like this:
+and after changes it should look like this:
 ```
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 333093 Maintainer: someone Status: ready -->
-<!-- $Revision$ -->
+<!-- EN-Revision: 68a9c82e06906a5c00e0199307d87dd3739f719b Maintainer: someone Status: ready -->
 <!-- CREDITS: johnsmith -->
 ```
-The new EN-Revision number came from the diff shown above. If you want to add
+The new EN-Revision came from the diff shown above. If you want to add
 yourself to a CREDITS tag that already exists, separate
 usernames with a comma, i.e.: `<!-- CREDITS: george, johnsmith -->`.
 

--- a/tutorial/user-notes.md
+++ b/tutorial/user-notes.md
@@ -1,11 +1,11 @@
 # User Note Editing Guidelines
 These are some guidelines to follow when editing user notes in the manual.
 
-To begin editing user notes in the manual, you must have SVN commit access to the manual, and you must either:
+To begin editing user notes in the manual, you must have GitHub access to the manual, and you must either:
 - Subscribe to the `php-notes` mailing list or newsgroup. As a user submits a new user note, it will appear
   as a message on the mailing list with links in the footer of the email that enable you to delete, edit,
   or reject that particular note.
-- Log on to the server at https://main.php.net/manage/user-notes.php using your SVN user ID and password.
+- Log on to the server at https://main.php.net/manage/user-notes.php using your PHP account user ID and password.
   The user notes administration interface enables you to search for user notes that match particular strings
   and edit or change the status of particular notes directly through the Web interface.
 


### PR DESCRIPTION
The documentation uses an old "SVN account",
as PHP account and access in GitHub are different things, I propose to separate two concepts in the documentation: 
PHP account (means SVN account) and GitHub access (means GitHub membership in PHP organization)