### PR TITLE
Change directory that doc-en is cloned into

### DIFF
--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -18,7 +18,7 @@ Adjust accordingly, including paths, especially if you are on Windows.
 ```
 $ mkdir /tmp/git
 $ cd /tmp/git
-$ git clone https://github.com/php/doc-en.git
+$ git clone https://github.com/php/doc-en.git doc-en/en
 $ cd /tmp/git/doc-en
 ```
 


### PR DESCRIPTION
The reasoning for this change is so that it's easier to start working with the docs with fresh clones from github. `doc-base/configure.php` expects an `en` directory, but if I clone `doc-en` repo from github, I have a `doc-en` directory with manual contents in the `doc-en` folder. This requires further renaming and directory juggling to get the tooling to work together nicely. By cloning into `doc-en/en`, this leaves a `doc-en` base directory that can contain `en` for the `doc-en` repo, `phd` and `doc-base`, then the rest of the tutorial instructions work nicely.