### PR TITLE
Set no-cache for generated images

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -9,3 +9,9 @@ RewriteRule ^tutorial/([a-z\-]*).php$ /tutorial.php?chapter=$1 [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ /redirect.php
+
+<IfModule mod_headers.c>
+    <FilesMatch "\.(jpg|jpeg|png|gif)$">
+        Header set Cache-Control no-cache
+    </FilesMatch>
+</IfModule>


### PR DESCRIPTION
This way generated images are always reloaded by the users. In my specific case, I tried to include the image in the [doc-it README.md](https://github.com/php/doc-it/blob/master/README.md), but I see that it doesn't refresh because of the missing header in the server response. You can read more about it [here](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/about-anonymized-urls#an-image-that-changed-recently-is-not-updating) and [here](https://github.com/atom/markdown-preview/issues/207).