### PR TITLE
revise wording for building docs tutorial

### DIFF
--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -4,27 +4,29 @@ This appendix describes how to check out, build and view the PHP documentation l
 Viewing results as a php.net mirror isn't a simple process, but it can be done.
 The following is one route, and it assumes:
 
-- PHP 5.4+ is available
+- PHP 7.2+ is available
 - Git version control system is available
+- DOM, libXML2, XMLReader, and SQLite3 are available
 - A basic level of shell/terminal usage, or know that shell commands follow a `$` below
 
 If you're interested in simply setting up a local PHP mirror (and NOT build the documentation) then
 please follow the php.net [mirroring guidelines](http://php.net/mirroring) and ignore this document.
 
 ## Checkout the php documentation from Git
-**Assumptions**: This assumes using `/tmp` as the root directory, and checkout of the English language.
-Adjust accordingly, including paths, especially if you are on Windows.
+**Assumptions**: This assumes creating a new directory to containing the various repositories necessary to build the
+docs, including checking out the English language repository. Adjust accordingly, including paths, especially if you
+are on Windows.
 
 ```
-$ mkdir /tmp/git
-$ cd /tmp/git
-$ git clone https://github.com/php/doc-en.git
-$ cd /tmp/git/doc-en
+$ mkdir ~/phpdoc
+$ cd ~/phpdoc
+$ git clone https://github.com/php/doc-en.git en
+$ git clone https://github.com/php/doc-base.git
 ```
 
 ## Validate the PHP Documentation XML
 ```
-$ cd /tmp/git/doc-en
+$ cd ~/phpdoc
 $ php doc-base/configure.php
 ```
 
@@ -35,58 +37,62 @@ PDF, Man, Epub, and others, including PHP which is what we use at php.net.
 
 ### Install PhD
 ```
-$ cd /tmp
+$ cd ~/phpdoc
 $ git clone https://github.com/php/phd.git
 $ php phd/render.php --help
 ```
 
 ### Use PhD to build the documentation
 ```
-$ cd /tmp/git/doc-en
+$ cd ~/phpdoc
 $ php doc-base/configure.php
-$ php /tmp/phd/render.php --docbook /tmp/git/doc-en/doc-base/.manual.xml --package PHP --format php
-$ cd /tmp/git/doc-en/mydocs/php-web/
+$ php ~/phpdoc/phd/render.php --docbook ~/phpdoc/doc-base/.manual.xml --package PHP --format php
+$ cd ~/phpdoc/output/php-web
 ```
 
-**Note:** This builds the php.net version of the documentation, but does not contain
-the files and includes used to run php.net. In other words, files like the php.net
-headers and footers are not built by PhD and are instead stored in a separate git
-module (web-php).
+PhD creates the `output` directory and builds the PHP manual files into the `output/php-web` directory.
+
+**Note:** This builds the php.net version of the documentation, but does not include the necessary files to run
+php.net. In other words, files like the php.net headers and footers are not built by PhD and are instead stored in a
+[separate git module (web-php)](https://github.com/php/web-php).
 
 Alternative: The XHTML format is simple and does not require mirroring the php.net
 website. The following builds manual pages as plain HTML files:
 ```
-$ cd /tmp/git/doc-en
+$ cd ~/phpdoc
 $ php doc-base/configure.php
-$ php /tmp/phd/render.php --docbook /tmp/git/doc-en/doc-base/.manual.xml --package PHP --format xhtml
-$ cd /tmp/phd/output/php-chunked-xhtml/
+$ php ~/phpdoc/phd/render.php --docbook ~/phpdoc/doc-base/.manual.xml --package PHP --format xhtml
+$ cd ~/phpdoc/output/php-chunked-xhtml/
 $ open function.strlen.html
 ```
 
 ## Set up a local php.net mirror
 ### Clone the php.net sources
 ```
-$ git clone https://github.com/php/web-php.git /home/sites/myphpnet/
+$ cd ~/phpdoc
+$ git clone https://github.com/php/web-php.git myphpnet
 ```
 
 ### Symlink (or move) the generated PHP documentation to your local php.net sources
 ```
-$ ln -s /tmp/phd/output/php-web /home/sites/myphpnet/manual/en
+$ cd ~/phpdoc/myphpnet/manual
+$ rm -rf en
+$ ln -s ~/phpdoc/output/php-web ~/phpdoc/myphpnet/manual/en
 ```
 
 Symlinking can also be done on Windows. Just make sure you run `cmd` *as Administrator*.
 
 ```
-$ cd \home\sites\myphpnet\manual\
+$ cd \your\path\to\myphpnet\manual\
 $ rmdir /S en
-$ mklink /D en \tmp\phd\output\web-php
+$ mklink /D en \your\path\to\output\web-php
 ```
 
 ### Run a webserver
 We are going to use PHP's built-in web server. Please open another terminal instance for this task.
 
 ```
-$ cd /home/sites/myphpnet/
+$ cd ~/phpdoc/myphpnet/
 $ php -S localhost:8080
 ```
 

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -4,7 +4,7 @@ This appendix describes how to check out, build and view the PHP documentation l
 Viewing results as a php.net mirror isn't a simple process, but it can be done.
 The following is one route, and it assumes:
 
-- PHP 7.2+, DOM, libXML2, XMLReader, and SQLite3 are available
+- PHP 7.2+, with the following extensions enabled: DOM, libXML2, XMLReader, and SQLite3
 - Git version control system is available
 - A basic level of shell/terminal usage, or know that shell commands follow a `$` below
 

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -81,7 +81,7 @@ $ git clone https://github.com/php/web-php.git myphpnet
 ```
 $ cd myphpnet/manual
 $ rm -rf en
-$ ln -s output/php-web myphpnet/manual/en
+$ ln -s ../../output/php-web en
 ```
 
 Symlinking can also be done on Windows. Just make sure you run `cmd` *as Administrator*.

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -4,9 +4,8 @@ This appendix describes how to check out, build and view the PHP documentation l
 Viewing results as a php.net mirror isn't a simple process, but it can be done.
 The following is one route, and it assumes:
 
-- PHP 7.2+ is available
+- PHP 7.2+, DOM, libXML2, XMLReader, and SQLite3 are available
 - Git version control system is available
-- DOM, libXML2, XMLReader, and SQLite3 are available
 - A basic level of shell/terminal usage, or know that shell commands follow a `$` below
 
 If you're interested in simply setting up a local PHP mirror (and NOT build the documentation) then
@@ -18,7 +17,7 @@ please follow the php.net [mirroring guidelines](http://php.net/mirroring) and i
  * doc-base 
  * phd
 
-If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the "Set up a local php.net mirror" section.
+If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the [Set up a local php.net mirror](/#set-up-a-local-phpnet-mirror) section.
 
 Note that `doc-en` is cloned into the `en` directory below.
 ```
@@ -30,56 +29,51 @@ $ git clone https://github.com/php/doc-base.git
 
 ## Validate the PHP Documentation XML
 ```
-$ cd phpdoc
 $ php doc-base/configure.php
 ```
+Running `configure.php` will run check and verify that the changes made to the XML validate with Docbook specification. If you receive an error message: resolve the error message and try running the configure.php script again. If you see an ASCII cat, your XML is valid.
 
 ## Build the documentation
-We use PhD to build the documentation. It takes the source that configure.php generates, and builds
+We use PhD to build the documentation. It takes the source that `configure.php` generates, and builds
 and formats the PHP documentation. PhD offers several formats including HTML (multiple or single page),
 PDF, Man, Epub, and others, including PHP which is what we use at php.net.
 
 ### Install PhD
 ```
-$ cd phpdoc
 $ git clone https://github.com/php/phd.git
 $ php phd/render.php --help
 ```
 
 ### Use PhD to build the documentation
+As previously stated, there are multiple formats PhD can build the docs, but the two most commonly used for checking changes are XHTML and PHP. Building the docs into PHP requires a web server to view the pages, whereas XHTML does not. For small changes, for example, affects only one page, building docs into XHTML is likely preferable.
 ```
-$ cd phpdoc
+$ php doc-base/configure.php
+$ php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml
+$ open output/php-chunked-xhtml/function.strlen.html
+```
+
+However, if you wish to view the docs in an environment that closely resembles php.net, or wish to host a local mirror, the docs should be built in PHP format.
+
+```
 $ php doc-base/configure.php
 $ php phd/render.php --docbook doc-base/.manual.xml --package PHP --format php
-$ cd output/php-web
 ```
+During the rendering process, PhD creates an `output` directory and builds the PHP manual files into a `php-web` directory inside of `output`.
 
-PhD creates the `output` directory and builds the PHP manual files into the `output/php-web` directory.
-
-**Note:** This builds the php.net version of the documentation, but does not include the necessary files to run
+**Note**: This builds the php.net version of the documentation, but does not include the necessary files to run
 php.net. In other words, files like the php.net headers and footers are not built by PhD and are instead stored in a
 [separate git module (web-php)](https://github.com/php/web-php).
 
-Alternative: The XHTML format is simple and does not require mirroring the php.net
-website. The following builds manual pages as plain HTML files:
-```
-$ cd phpdoc
-$ php doc-base/configure.php
-$ php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml
-$ cd output/php-chunked-xhtml/
-$ open function.strlen.html
-```
-
+<a id="set-up-a-local-phpnet-mirror"></a>
 ## Set up a local php.net mirror
 ### Clone the php.net sources
 ```
-$ cd phpdoc
-$ git clone https://github.com/php/web-php.git myphpnet
+$ git clone https://github.com/php/web-php.git
 ```
 
 ### Symlink (or move) the generated PHP documentation to your local php.net sources
 ```
-$ cd myphpnet/manual
+$ cd web-php/manual
 $ rm -rf en
 $ ln -s ../../output/php-web en
 ```
@@ -87,7 +81,7 @@ $ ln -s ../../output/php-web en
 Symlinking can also be done on Windows. Just make sure you run `cmd` *as Administrator*.
 
 ```
-$ cd \your\path\to\myphpnet\manual\
+$ cd \your\path\to\web-php\manual\
 $ rmdir /S en
 $ mklink /D en \your\path\to\output\web-php
 ```
@@ -96,8 +90,8 @@ $ mklink /D en \your\path\to\output\web-php
 We are going to use PHP's built-in web server. Please open another terminal instance for this task.
 
 ```
-$ cd phpdoc/myphpnet
-$ php -S localhost:8080
+$ cd phpdoc/web-php
+$ php -S localhost:8080 .router.php
 ```
 
 ## View the new site

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -17,7 +17,7 @@ please follow the php.net [mirroring guidelines](http://php.net/mirroring) and i
  * doc-base 
  * phd
 
-If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the [Set up a local php.net mirror](/#set-up-a-local-phpnet-mirror) section.
+If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the <a href="#set-up-a-local-phpnet-mirror">Set up a local php.net mirror</a> section.
 
 Note that `doc-en` is cloned into the `en` directory below.
 ```

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -13,20 +13,24 @@ If you're interested in simply setting up a local PHP mirror (and NOT build the 
 please follow the php.net [mirroring guidelines](http://php.net/mirroring) and ignore this document.
 
 ## Checkout the php documentation from Git
-**Assumptions**: This assumes creating a new directory to containing the various repositories necessary to build the
-docs, including checking out the English language repository. Adjust accordingly, including paths, especially if you
-are on Windows.
+**Assumptions**: A working directory `phpdoc` is created and will contain the necessary cloned repositories. This tutorial will reference the directories that repositories are cloned into. Adjust as needed, including paths, especially if you are on Windows. This tutorial will clone at least three repositories:
+ * doc-en (into the `en` directory)
+ * doc-base 
+ * phd
 
+If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the "Set up a local php.net mirror" section. <!-- a link to the "Set up local php.net mirror" is preferrable, but I'm unsure if [Set up a local php.net mirror](/#set-up-a-local-phpnet-mirror) will work between markdown and doc.php.net since doc.php.net/tutorial/local-setup.php does not have anchor headings --> 
+
+Note that `doc-en` is cloned into the `en` directory below.
 ```
-$ mkdir ~/phpdoc
-$ cd ~/phpdoc
+$ mkdir phpdoc
+$ cd phpdoc
 $ git clone https://github.com/php/doc-en.git en
 $ git clone https://github.com/php/doc-base.git
 ```
 
 ## Validate the PHP Documentation XML
 ```
-$ cd ~/phpdoc
+$ cd phpdoc
 $ php doc-base/configure.php
 ```
 
@@ -37,17 +41,17 @@ PDF, Man, Epub, and others, including PHP which is what we use at php.net.
 
 ### Install PhD
 ```
-$ cd ~/phpdoc
+$ cd phpdoc
 $ git clone https://github.com/php/phd.git
 $ php phd/render.php --help
 ```
 
 ### Use PhD to build the documentation
 ```
-$ cd ~/phpdoc
+$ cd phpdoc
 $ php doc-base/configure.php
-$ php ~/phpdoc/phd/render.php --docbook ~/phpdoc/doc-base/.manual.xml --package PHP --format php
-$ cd ~/phpdoc/output/php-web
+$ php phd/render.php --docbook doc-base/.manual.xml --package PHP --format php
+$ cd output/php-web
 ```
 
 PhD creates the `output` directory and builds the PHP manual files into the `output/php-web` directory.
@@ -59,25 +63,25 @@ php.net. In other words, files like the php.net headers and footers are not buil
 Alternative: The XHTML format is simple and does not require mirroring the php.net
 website. The following builds manual pages as plain HTML files:
 ```
-$ cd ~/phpdoc
+$ cd phpdoc
 $ php doc-base/configure.php
-$ php ~/phpdoc/phd/render.php --docbook ~/phpdoc/doc-base/.manual.xml --package PHP --format xhtml
-$ cd ~/phpdoc/output/php-chunked-xhtml/
+$ php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml
+$ cd output/php-chunked-xhtml/
 $ open function.strlen.html
 ```
 
 ## Set up a local php.net mirror
 ### Clone the php.net sources
 ```
-$ cd ~/phpdoc
+$ cd phpdoc
 $ git clone https://github.com/php/web-php.git myphpnet
 ```
 
 ### Symlink (or move) the generated PHP documentation to your local php.net sources
 ```
-$ cd ~/phpdoc/myphpnet/manual
+$ cd myphpnet/manual
 $ rm -rf en
-$ ln -s ~/phpdoc/output/php-web ~/phpdoc/myphpnet/manual/en
+$ ln -s output/php-web myphpnet/manual/en
 ```
 
 Symlinking can also be done on Windows. Just make sure you run `cmd` *as Administrator*.
@@ -92,7 +96,7 @@ $ mklink /D en \your\path\to\output\web-php
 We are going to use PHP's built-in web server. Please open another terminal instance for this task.
 
 ```
-$ cd ~/phpdoc/myphpnet/
+$ cd phpdoc/myphpnet
 $ php -S localhost:8080
 ```
 

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -17,7 +17,7 @@ please follow the php.net [mirroring guidelines](http://php.net/mirroring) and i
  * doc-base 
  * phd
 
-If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the <a href="#set-up-a-local-phpnet-mirror">Set up a local php.net mirror</a> section.
+If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the [Set up a local php.net mirror](#set-up-a-local-phpnet-mirror) section.
 
 Note that `doc-en` is cloned into the `en` directory below.
 ```

--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -18,7 +18,7 @@ please follow the php.net [mirroring guidelines](http://php.net/mirroring) and i
  * doc-base 
  * phd
 
-If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the "Set up a local php.net mirror" section. <!-- a link to the "Set up local php.net mirror" is preferrable, but I'm unsure if [Set up a local php.net mirror](/#set-up-a-local-phpnet-mirror) will work between markdown and doc.php.net since doc.php.net/tutorial/local-setup.php does not have anchor headings --> 
+If setting up a local php.net mirror is desired, the `web-php` repository must also be cloned. This is explained in the "Set up a local php.net mirror" section.
 
 Note that `doc-en` is cloned into the `en` directory below.
 ```


### PR DESCRIPTION
This improves upon https://github.com/php/web-doc/pull/15 which uses the directory structure from [doc-base's readme](https://github.com/php/doc-base#readme). I've also revised some assumptions and notes.

I was not able to fully test the symlink section, but I _believe_ it's correct.