### PR TITLE
Include JSON extension for phd

### DIFF
--- a/tutorial/local-setup.md
+++ b/tutorial/local-setup.md
@@ -4,7 +4,7 @@ This appendix describes how to check out, build and view the PHP documentation l
 Viewing results as a php.net mirror isn't a simple process, but it can be done.
 The following is one route, and it assumes:
 
-- PHP 7.2+, with the following extensions enabled: DOM, libXML2, XMLReader, and SQLite3
+- PHP 7.2+, with the following extensions enabled: DOM, libXML2, XMLReader, JSON and SQLite3
 - Git version control system is available
 - A basic level of shell/terminal usage, or know that shell commands follow a `$` below
 


### PR DESCRIPTION
While following the docs on http://doc.php.net/tutorial/local-setup.php, I got the following error due to a missing extension.

I know that as of PHP 8 JSON will always be available, but since the docs point to PHP 7.2+ I think mentioning JSON doesn't hurt

```
PHP Fatal error:  Uncaught Error: Call to undefined function phpdotnet\phd\json_encode() in /app/phd/phpdotnet/phd/Package/PHP/Web.php:224
```