### PR TITLE
Implement [skip-revcheck] to exclude a commit from consideration

### DIFF
--- a/scripts/rev.php
+++ b/scripts/rev.php
@@ -438,6 +438,7 @@ function captureGitValues( & $output )
         if ( substr( $line , 0 , 7 ) == "commit " )
         {
             $hash = trim( substr( $line , 7 ) );
+            $skipThisCommit = false;
             continue;
         }
         if ( strpos( $line , 'Date:' ) === 0 )

--- a/scripts/rev.php
+++ b/scripts/rev.php
@@ -432,6 +432,7 @@ function captureGitValues( & $output )
     $hash = null;
     $date = null;
     $utct = new DateTimeZone( "UTC" );
+    $skipThisCommit = false;
     while ( ( $line = fgets( $fp ) ) !== false )
     {
         if ( substr( $line , 0 , 7 ) == "commit " )
@@ -447,11 +448,19 @@ function captureGitValues( & $output )
         if ( trim( $line ) == "" )
             continue;
         if ( substr( $line , 0 , 4 ) == '    ' )
+        {
+            if ( stristr( $line, '[skip-revcheck]' ) !== false )
+            {
+                $skipThisCommit = true;
+            }
             continue;
+        }
         if ( strpos( $line , ': ' ) > 0 )
             continue;
         $filename = trim( $line );
         if ( isset( $output[$filename] ) )
+            continue;
+        if ( $skipThisCommit )
             continue;
         $output[$filename]['hash'] = $hash;
     }


### PR DESCRIPTION
Discussion: https://github.com/php/doc-en/pull/858#issuecomment-903723978

---

This adds a new feature to the documentation translations checker:

Including the text:

> [skip-revcheck]

in your commit message will exclude a commit from consideration in the tools at http://doc.php.net/revcheck.php

You should use this when:

- Making typo corrections to the EN documentation that do not require the attention of the translations teams.
- Making formatting corrections to the EN documentation that do not require the attention of the translations teams.

---

I am not sure where to add that additional documentation meta notes. But I hope we can please document it as part of this PR.