### PR TITLE
Fix generic font-family name

### DIFF
--- a/include/lib_revcheck.inc.php
+++ b/include/lib_revcheck.inc.php
@@ -255,7 +255,7 @@ function showdiff ()
         $raw = htmlspecialchars( $file, ENT_XML1, 'UTF-8' );
         $trans = [ " " => "&nbsp;" ];
         $lines = explode ( "\n" , $raw );
-        echo "<div style='font:87% mono;overflow-wrap:break-word;'>";
+        echo "<div style='font:87% monospace;overflow-wrap:break-word;'>";
         foreach ( $lines as $line ) {
             $inline = strtr( $line , $trans );
             $fc = substr( $inline , 0 , 1 );


### PR DESCRIPTION
`mono` isn't a [valid generic font-family](https://drafts.csswg.org/css-fonts/#generic-font-families), `monospace` should be used instead.

Fixes serif font bug on some systems:
![Before](https://user-images.githubusercontent.com/7695608/147708730-dea5c1c7-9033-48d1-a420-2b14f1f05cd8.png)
![After](https://user-images.githubusercontent.com/7695608/147708770-3ccc3719-f204-4608-9c93-e9f41d755a82.png)

