### PR TITLE
Show additions and deletions

### DIFF
--- a/include/lib_revcheck.inc.php
+++ b/include/lib_revcheck.inc.php
@@ -48,7 +48,7 @@ function get_dirs($idx, $lang) {
 // return an array with the outdated files; can be optionally filtered by user or dir
 function get_outdated_files($idx, $lang, $filter = null, $value = null)
 {
-    $sql = "SELECT a.status, a.name AS file, a.maintainer, c.revision AS en_rev, a.revision AS trans_rev, b.path AS dir
+    $sql = "SELECT a.status, a.name AS file, a.maintainer, a.additions, a.deletions, c.revision AS en_rev, a.revision AS trans_rev, b.path AS dir
     FROM translated a, dirs b, enfiles c
     WHERE a.lang = '$lang'
       AND c.name = a.name AND b.id = a.id AND b.id = c.id
@@ -73,7 +73,9 @@ function get_outdated_files($idx, $lang, $filter = null, $value = null)
         'trans_rev' => $r['trans_rev'],
         'status' => $r['status'],
         'maintainer' => $r['maintainer'],
-        'name' => $r['dir']);
+        'name' => $r['dir'],
+        'additions' => $r['additions'],
+        'deletions' => $r['deletions']);
     }
 
     return $tmp;

--- a/www/revcheck.php
+++ b/www/revcheck.php
@@ -327,6 +327,7 @@ HTML;
 <table border="0" cellpadding="4" cellspacing="1" style="text-align:center">
 <tr>
 <th rowspan="2">Translated file</th>
+<th rowspan="2">Changes</th>
 <th colspan="2">Revision</th>
 <th rowspan="2">Maintainer</th>
 <th rowspan="2">Status</th>
@@ -335,14 +336,14 @@ HTML;
 <th>en</th>
 <th>$lang</th>
 </tr>
-<tr><th colspan="5">{$outdated[0]['name']}</th></tr>
+<tr><th colspan="6">{$outdated[0]['name']}</th></tr>
 END_OF_MULTILINE;
         $last_dir = false;
         $prev_name = $outdated[0]['name'];
 
         foreach ($outdated as $r) {
             if ($r['name'] != $prev_name) {
-            echo '<tr><th colspan="5">'.$r['name'].'</th></tr>';
+            echo '<tr><th colspan="6">'.$r['name'].'</th></tr>';
             $prev_name = $r['name'];
         }
 
@@ -369,9 +370,12 @@ END_OF_MULTILINE;
 
         $nm = "<a href='$d2'>{$r['file']}</a> <a href='$d1'>[diff]</a>";
 
+        $ch = "<span style='color: darkgreen;'>+{$r['additions']}</span> <span style='color: firebrick;'>-{$r['deletions']}</span>";
+
         // Write out the line for the current file (get file name shorter)
         echo '<tr>'.
         "<td style='white-space:nowrap'>{$nm}</td>".
+        "<td style='font-size: 14px; text-align: right;'>{$ch}</td>" .
         "<td>{$h1}</td>" .
         "<td>{$h2}</td>" .
         "<td> {$r['maintainer']}</td>" .


### PR DESCRIPTION
## Intro
If accepted, this PR will add additions and deletions counts to the outdated files table. This helps translators coordinate efforts and choose a file according to the time they have available. The change counts are displayed in the standard `+42 -42` format.

## Preview
![Preview image](https://user-images.githubusercontent.com/7695608/148706367-99577f3c-d520-43a4-9b28-a051b9f5470e.png)

## "Crowded" Table
I am aware that this change further increases the amount of information in the table, which is already very polluted.
I have a proposal to address this issue, however I have not included here initially, as it is outside the scope of this PR.

- Lighten table stripes (only affects file rows, directory rows doesn't change)
- Remove underline from links (this table only)
- Left align file names, so our eyes are able to scan the list faster.
- Display a truncated version of the hash with 7 characters. We can move the full hashes to the file diff page, as we are usually at it when we want to copy the new revision hash.

Please let me know if you would like me to include improved table styles in this Pull Request. Preview:
![table](https://user-images.githubusercontent.com/7695608/148720689-0b6f9482-5f0b-4f37-b27a-f18df8fde340.gif)