### PR TITLE
Fix diff header skip

### DIFF
--- a/include/lib_revcheck.inc.php
+++ b/include/lib_revcheck.inc.php
@@ -279,7 +279,10 @@ function showdiff ()
 
         echo "<div style='padding: 12px;'>$gitfile</div>";
 
-        foreach (array_slice($lines, 4) as $line) {
+        // Count how many lines to skip diff header
+        $diffStartLine = substr_count($raw, "\n", 0, strpos($raw, ' @@'));
+
+        foreach (array_slice($lines, $diffStartLine) as $line) {
             $fc = substr( $line , 0 , 1 );
 
             echo "<div style='display: flex;'>";


### PR DESCRIPTION
The git diff header has 5 lines instead of 4 when a file is added, which is causing [a bug](http://doc.php.net/revcheck.php?p=plain&lang=pt_br&hbp=4eefb1e936f416333e05635b0ca2ac10166fdcec&f=language/predefined/error/gettraceasstring.xml&c=on) in files with invalid hashes:
![image](https://user-images.githubusercontent.com/7695608/148783353-41bc0dfb-d9c3-4b40-a3c3-c34f20f87540.png)