### PR TITLE
Add style guideline regarding conditional conjunction formatting

### DIFF
--- a/tutorial/style.md
+++ b/tutorial/style.md
@@ -38,7 +38,9 @@ Example: `<entry>5.2.11, 5.3.1</entry>`
 ## General Grammar
 The PHP Manual should be written with particular attention to general English grammar. Contractions should be used
 appropriately. Special attention should be applied to sentence construction when using prepositions (i.e., sentences
-should not end in prepositions).
+should not end in prepositions). If a statement includes a conditional conjunction, the condition being met should come 
+before the independent clause. The previous statement is an example of how a conditional conjuction should be formatted.
+See [PR#1565](https://github.com/php/doc-en/pull/1565) for another example.
 
 ## PHP Manual Terms
 Various non-english, technical terms are used throughout the PHP Manual, without clear indication of their appropriate


### PR DESCRIPTION
Statements which contain a conditional conjunction should be condition first, clause second. There are places in the manual which are formatted the opposite, which can cause confusion for some readers. There are occasionally PRs to doc-en to improve the wording on these statements, but there isn't a formal guideline on how these statements should be formatted. This PR intends to change that.

See https://github.com/php/doc-en/pull/1565