### PR TITLE
Update the 'Joining the team' documentation

### DIFF
--- a/tutorial/joining.md
+++ b/tutorial/joining.md
@@ -8,16 +8,23 @@ Say "Hi" and what you're interested in doing. You may feel more comfortable lurk
 for a while, or reading the archives, but ultimately let the list know who you are.
 
 ### For authors
-You should send your message to the `phpdoc@lists.php.net` mailing list.
+You should send your message to the `phpdoc@lists.php.net` mailing list. You
+will need to subscribe to the list in order to send email to it.
 
 ### For translators
 You should send your message to the appropriate `doc-{LANG}@lists.php.net` mailing list.
 
 ## Informal discussion
+The mailing lists above are the primary communication forum. In particular,
+decisions and plans should be made on the list so they are recorded in the
+archives.
 
-The mailing lists above are the primary communication forum. However for more
-realtime and/or informal chat, some doc authors hang out in "Room 11" on
-Stackoverflow Chat: https://chat.stackoverflow.com/rooms/11/php
+However for more realtime and/or informal chat, some doc authors hang out in
+"Room 11" on Stackoverflow Chat: https://chat.stackoverflow.com/rooms/11/php
+
+Some authors hang out in the `#php-doc` channel on IRC on the
+https://Libera.Chat network, which is also bridged to the Discord server run
+by the PHP Community Foundation, available at https://phpc.chat.
 
 ## Create a doc patch or three
 This step is required to show us that you are a real human, you want to do
@@ -29,15 +36,15 @@ to [php/doc-en][doc-en] or php/doc-{LANG} for translations.
 Your Pull Requests will be then reviewed and accepted by someone with Git commit access.
 
 ## Obtaining Git commit access
-If you plan to contribute to the manual regularly, and want to do this more efficiently,
-you probably would like to be able to push to Git directly. This requires a PHP.net account.
+If you plan to contribute to the manual regularly and want to help process
+contributions from others, you might want to request to be added to the
+documentation team (or a translation team) on GitHub, which you can do on the
+email lists.
 
-To request one, please fill in [this form][request-account].
-
-Provide links to your work that has already been committed and/or list your current patches.
-Basically, tell us what you have done, to prove that you really need this account.
+To be clear: you don't need Git commit access to start contributing to the
+documentation! Anyone with a GitHub account (which is free) can submit Pull
+Requests to the documentation repositories.
 
 The next chapter will explain how to get the manual sources and how are they [structured](structure.php).
 
-[request-account]: http://php.net/git-php.php
 [doc-en]: https://github.com/php/doc-en


### PR DESCRIPTION
Mention the IRC and Discord channels, and remove out-of-date info about needing a PHP VCS account.