### PR TITLE
Add styling, overflow for `<pre>` blocks (closes #46)

### DIFF
--- a/include/lib_general.inc.php
+++ b/include/lib_general.inc.php
@@ -52,6 +52,13 @@ td { background-color: #dcdcdc; padding: 0.2em 0.3em; }
 .copy { margin:0; padding: 0; font-size:small; }
 .copy:hover { text-transform: uppercase; }
 .copy:active { background: aqua; font-weight: bold; }
+pre {
+    background: white;
+    border: solid 1px rgb(214, 214, 214);
+    padding: 0.75rem;
+    overflow: auto;
+    font: normal 0.875rem/1.5rem "Source Code Pro", monospace;
+}
 </style>
 END_OF_MULTILINE;
     echo '<section class="mainscreen">';

--- a/include/lib_revcheck.inc.php
+++ b/include/lib_revcheck.inc.php
@@ -249,7 +249,8 @@ function showdiff ()
         chdir( GIT_DIR . 'en' );
         $arg_h = escapeshellarg($h);
         $arg_f = escapeshellarg($gitfile);
-        $file = `git -c {$safedir} diff --ignore-space-at-eol {$arg_h} -- {$arg_f}`;
+        echo "git -c {$safedir} diff -b --word-diff=porcelain {$arg_h} -- {$arg_f}";
+        $file = `git -c {$safedir} diff -b --word-diff=porcelain {$arg_h} -- {$arg_f}`;
         if ($file == null)
             $file = `git -c {$safedir} diff {$arg_h} -- {$arg_f}`;
         $hash = `git -c {$safedir} log -n 1 --pretty=format:%H -- {$arg_f}`;


### PR DESCRIPTION
The base styles for doc.php.net and www.php.net aren't in total alignment, but this at least brings over some of the styling for `<pre>` blocks (border, padding, overflow).