### PR TITLE
Mention JpGraph in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ contributors to find useful guides, tools, statistics etc.
 
 ## Running a local version
 
-This can be run using PHP's [built-in web server][webserver]
+This can be run using PHP's [built-in web server](https://www.php.net/features.commandline.webserver)
 for local development. For the guide pages to work, you also
 need a local clone of the `doc-base` repository.
 
 To generate the images for translation status, the GD extension
 is required.
+[JpGraph](https://jpgraph.net/download/) needs to be in `/include/jpgraph/`.
 
 To generate the translation status, you'll also need the English version
 of the documentation and whatever languages you want to generate data


### PR DESCRIPTION
This was accidentally removed in 5e42e51.
Also link PHP's built-in web server.