### PR TITLE
Fix image margin on translation status

### DIFF
--- a/www/img-status-all.php
+++ b/www/img-status-all.php
@@ -35,7 +35,7 @@ $graph->ygrid->SetFill(true,'#EFEFEF@0.5','#BBCCFF@0.5');
 $graph->SetShadow();
 
 // Adjust the margin a bit to make more room for titles
-$graph->img->SetMargin(50,30,20,40);
+$graph->img->SetMargin(50,30,35,40);
 
 // Create a bar pot
 $bplot = new BarPlot($percent);


### PR DESCRIPTION
This fixes the percentage overlapping with the title.

Before

![php_status](https://doc.php.net/img-status-all.php)

After (with this PR):

![image](https://github.com/user-attachments/assets/02da1cb5-f32a-4dfa-923f-40ae20258f76)
