### PR TITLE
Add cross-language translation status view

### DIFF
--- a/include/lib_general.inc.php
+++ b/include/lib_general.inc.php
@@ -89,6 +89,9 @@ function nav_languages($lang = null)
     $out .= '<p class="headline"><a href="/revcheck.php">Translation status</a></p>';
     $out .= '<div class="body">';
     $out .= '<ul>';
+    if ($lang === null) {
+        $out .= '<li><a href="/revcheck.php?p=alllangs&amp;lang=en">All languages</a></li>';
+    }
     foreach ($LANGUAGES as $code => $name)
     {
         $out .= '<li><a href="/revcheck.php?lang='.$code.'">'.$name.'</a>';

--- a/include/lib_revcheck.inc.php
+++ b/include/lib_revcheck.inc.php
@@ -334,6 +334,82 @@ function showdiff ()
    }
 }
 
+// Return an array of distinct directories from the EN tree
+function get_dirs_en($idx) {
+    $sql = <<<SQL
+        SELECT DISTINCT
+            path AS dir
+        FROM
+            files
+        WHERE
+            lang = 'en'
+        ORDER BY
+            path
+    SQL;
+
+    $result = $idx->query($sql);
+
+    $tmp = [];
+    while ($r = $result->fetchArray()) {
+        $tmp[] = $r['dir'];
+    }
+
+    return $tmp;
+}
+
+// Return a matrix of file statuses across all translation languages for a given directory
+function get_files_all_langs($idx, $dir) {
+    global $LANGUAGES;
+
+    $dir = SQLite3::escapeString($dir);
+
+    // Get all EN files for this directory
+    $sql_en = <<<SQL
+        SELECT
+            name
+        FROM
+            files
+        WHERE
+            lang = 'en'
+        AND
+            path = '{$dir}'
+        ORDER BY
+            name
+    SQL;
+
+    $result = $idx->query($sql_en);
+    $files = [];
+    while ($r = $result->fetchArray(SQLITE3_ASSOC)) {
+        $files[$r['name']] = [];
+    }
+
+    // For each language, get the status of files in this directory
+    foreach (array_keys($LANGUAGES) as $lang) {
+        $lang = SQLite3::escapeString($lang);
+
+        $sql = <<<SQL
+            SELECT
+                name,
+                status
+            FROM
+                files
+            WHERE
+                lang = '{$lang}'
+            AND
+                path = '{$dir}'
+        SQL;
+
+        $result = $idx->query($sql);
+        while ($r = $result->fetchArray(SQLITE3_ASSOC)) {
+            if (isset($files[$r['name']])) {
+                $files[$r['name']][$lang] = $r['status'];
+            }
+        }
+    }
+
+    return $files;
+}
+
 function gen_date($file)
 {
     $unix = filemtime($file);

--- a/www/revcheck.php
+++ b/www/revcheck.php
@@ -19,8 +19,8 @@ if (isset($_GET['p'])) {
     $tool = $_GET['p'];
 }
 
-// Prevent viewing other tools in EN
-if ($lang == 'en') {
+// Prevent viewing other tools in EN (except alllangs)
+if ($lang == 'en' && $tool !== 'alllangs') {
     $tool = 'default';
 }
 
@@ -363,11 +363,77 @@ END_OF_MULTILINE;
     echo gen_date($DBLANG);
  break;
 
+ case 'alllangs':
+     $dirs_en = get_dirs_en($dbhandle);
+     $selected_dir = isset($_GET['dir']) ? $_GET['dir'] : ($dirs_en[0] ?? '');
+
+     echo '<h2>Translation status across all languages</h2>';
+     echo '<p>Choose a directory to see the translation status of each file across all languages.</p>';
+     echo '<form method="get" action="revcheck.php"><p><select name="dir">';
+     foreach ($dirs_en as $d) {
+         $sel = ($d === $selected_dir) ? ' selected="selected"' : '';
+         $display = $d === '' ? '/' : $d;
+         echo '<option value="' . htmlspecialchars($d) . '"' . $sel . '>' . htmlspecialchars($display) . '</option>';
+     }
+     echo '</select>';
+     echo '<input type="hidden" name="p" value="alllangs">';
+     echo '<input type="hidden" name="lang" value="en">';
+     echo '<input type="submit" value="Show status"></p></form>';
+
+     $files_matrix = get_files_all_langs($dbhandle, $selected_dir);
+
+     if (empty($files_matrix)) {
+         echo '<p>No files found in this directory.</p>';
+     } else {
+         $langs = array_keys($LANGUAGES);
+
+         echo '<table class="c">';
+         echo '<tr><th>File</th>';
+         foreach ($langs as $l) {
+             echo '<th>' . htmlspecialchars($l) . '</th>';
+         }
+         echo '</tr>';
+
+         foreach ($files_matrix as $filename => $statuses) {
+             echo '<tr>';
+             echo '<td class="n" style="text-align:left;">' . htmlspecialchars($filename) . '</td>';
+             foreach ($langs as $l) {
+                 $status = $statuses[$l] ?? 'Untranslated';
+                 [$label, $color] = match ($status) {
+                     'TranslatedOk'  => ['&#10003;', '#ccebc5'],
+                     'TranslatedOld' => ['old', '#fbb4ae'],
+                     'TranslatedWip' => ['wip', '#fed9a6'],
+                     'RevTagProblem' => ['tag', '#ffffcc'],
+                     'Untranslated'  => ['&mdash;', '#e0e0e0'],
+                     'NotInEnTree'   => ['?', '#decbe4'],
+                     default         => ['?', '#ffffff'],
+                 };
+                 echo '<td style="background-color:' . $color . ';" title="' . htmlspecialchars($TRANSLATION_STATUSES[$status] ?? $status) . '">' . $label . '</td>';
+             }
+             echo '</tr>';
+         }
+         echo '</table>';
+
+         echo '<p>';
+         echo '<span style="background-color:#ccebc5;padding:2px 6px;">&#10003;</span> Up to date &nbsp; ';
+         echo '<span style="background-color:#fbb4ae;padding:2px 6px;">old</span> Outdated &nbsp; ';
+         echo '<span style="background-color:#fed9a6;padding:2px 6px;">wip</span> Work in progress &nbsp; ';
+         echo '<span style="background-color:#ffffcc;padding:2px 6px;">tag</span> Missing revision tag &nbsp; ';
+         echo '<span style="background-color:#e0e0e0;padding:2px 6px;">&mdash;</span> Untranslated';
+         echo '</p>';
+     }
+
+     echo gen_date($DBLANG);
+     $sidebar = nav_languages();
+     site_footer($sidebar);
+ break;
+
  case 'graph':
  default:
      if ($lang == 'en') {
          echo '<img src="img-status-all.php" width="662" height="262" alt="Info" class="chart">';
          echo '<p>This is all what we can show for original manual. To get more tools, please select translation language.</p>';
+         echo '<p><a href="?p=alllangs&amp;lang=en">View translation status across all languages</a></p>';
          echo gen_date($DBLANG);
          $sidebar = nav_languages();
          site_footer($sidebar);


### PR DESCRIPTION
## Summary

- Adds a new `?p=alllangs` view on the EN revcheck page showing translation status across all languages as a color-coded matrix table