### PR TITLE
Show the do-not-translate and broken XML statuses

### DIFF
--- a/include/lib_general.inc.php
+++ b/include/lib_general.inc.php
@@ -100,6 +100,8 @@ function nav_languages($lang = null)
             $out .= '<li><a href="/revcheck.php?p=misstags&amp;lang='.$lang.'">Missing revision numbers</a></li>';
             $out .= '<li><a href="/revcheck.php?p=missfiles&amp;lang='.$lang.'">Untranslated files</a></li>';
             $out .= '<li><a href="/revcheck.php?p=oldfiles&amp;lang='.$lang.'">Not in EN tree</a></li>';
+            $out .= '<li><a href="/revcheck.php?p=brokenfiles&amp;lang='.$lang.'">Broken XML</a></li>';
+            $out .= '<li><a href="/revcheck.php?p=donottranslate&amp;lang='.$lang.'">Do not translate</a></li>';
             $out .= '</ul>';
         }
         $out .= '</li>';

--- a/include/lib_revcheck.inc.php
+++ b/include/lib_revcheck.inc.php
@@ -27,7 +27,14 @@ $TRANSLATION_STATUSES = [
     'RevTagProblem' => 'No revision tag',
     'NotInEnTree'   => 'Not in EN tree',
     'Untranslated'  => 'Available for translation',
+    'XmlBroken'     => 'Broken XML',
+    'DoNotTranslate' => 'Marked do not translate',
 ];
+
+// Files marked do not translate are never expected to be translated, so
+// they are listed but never counted against a translation. This matches
+// the totals of doc-base scripts/revcheck.php and genrevdb.php.
+$TRANSLATION_STATUSES_OFF_TOTAL = [ 'DoNotTranslate' ];
 
 function get_language_intro($idx, $lang) {
     $result = $idx->query("SELECT intro FROM languages WHERE lang = '$lang'");
@@ -161,6 +168,40 @@ function get_oldfiles($idx, $lang)
     return $tmp;
 }
 
+function get_brokenfiles($idx, $lang)
+{
+    $sql = <<<SQL
+        SELECT path AS dir, name AS name, xmlError AS error, size / 1024 AS size
+          FROM files
+         WHERE lang = '{$lang}' AND status = 'XmlBroken'
+         ORDER BY dir, name
+    SQL;
+
+    $result = $idx->query($sql);
+    $tmp = array();
+    while ($r = $result->fetchArray(SQLITE3_ASSOC)) {
+        $tmp[] = $r;
+    }
+    return $tmp;
+}
+
+function get_donottranslate($idx, $lang)
+{
+    $sql = <<<SQL
+        SELECT path AS dir, name AS name, size / 1024 AS size
+          FROM files
+         WHERE lang = '{$lang}' AND status = 'DoNotTranslate'
+         ORDER BY dir, name
+    SQL;
+
+    $result = $idx->query($sql);
+    $tmp = array();
+    while ($r = $result->fetchArray(SQLITE3_ASSOC)) {
+        $tmp[] = $r;
+    }
+    return $tmp;
+}
+
 function get_misstags($idx, $lang)
 {
     $sql = <<<SQL
@@ -221,9 +262,12 @@ function get_lang_stats($idx, $lang) {
     $stats = [];
     $total = [ 'total' => 0, 'size' => 0 ];
 
+    global $TRANSLATION_STATUSES_OFF_TOTAL;
+
     while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
         $stats[$row['status']] = $row;
-        if ($row['status'] != 'NotInEnTree') {
+        if ($row['status'] != 'NotInEnTree'
+            && !in_array($row['status'], $TRANSLATION_STATUSES_OFF_TOTAL)) {
             $total['total'] += $row['total'];
             $total['size'] += $row['size'];
         }

--- a/www/revcheck.php
+++ b/www/revcheck.php
@@ -180,6 +180,63 @@ TRANSLATORS_HEAD;
  echo gen_date($DBLANG);
  break;
 
+ case 'brokenfiles':
+     $brokenfiles = get_brokenfiles($dbhandle, $lang);
+
+     if (!$brokenfiles) {
+         echo '<p>Good, all translated files are valid XML.</p>';
+     } else {
+         $num = count($brokenfiles);
+         echo '<p>These files do not parse as XML. The manual build may fail, or silently ';
+         echo 'drop their contents, so they need a fix before anything else.</p>';
+         echo '<table class="c">';
+         echo '<tr><th>Broken XML files ('.$num.' files):</th><th>Error</th><th>kB</th></tr>';
+
+         $last_dir = false;
+         foreach ($brokenfiles as $row) {
+             if (!$last_dir || $last_dir != $row['dir']) {
+                 echo '<tr><th colspan="3">'.htmlspecialchars($row['dir']).'</th></tr>';
+                 $last_dir = $row['dir'];
+             }
+             echo '<tr>',
+                 '<td>', htmlspecialchars($row['name']), '</td>',
+                 '<td>', htmlspecialchars($row['error']), '</td>',
+                 '<td>', $row['size'], '</td>',
+                 '</tr>';
+         }
+         echo '</table>';
+     }
+     echo gen_date($DBLANG);
+ break;
+
+ case 'donottranslate':
+     $donottranslate = get_donottranslate($dbhandle, $lang);
+
+     if (!$donottranslate) {
+         echo '<p>No source file is marked do not translate.</p>';
+     } else {
+         $num = count($donottranslate);
+         echo '<p>These English files carry a <code>&lt;?do-not-translate?&gt;</code> mark. They are ';
+         echo 'not expected to be translated, and are left out of the totals of this translation.</p>';
+         echo '<table class="c">';
+         echo '<tr><th>Marked do not translate ('.$num.' files):</th><th>kB</th></tr>';
+
+         $last_dir = false;
+         foreach ($donottranslate as $row) {
+             if (!$last_dir || $last_dir != $row['dir']) {
+                 echo '<tr><th colspan="2">'.htmlspecialchars($row['dir']).'</th></tr>';
+                 $last_dir = $row['dir'];
+             }
+             echo '<tr>',
+                 '<td>', htmlspecialchars($row['name']), '</td>',
+                 '<td>', $row['size'], '</td>',
+                 '</tr>';
+         }
+         echo '</table>';
+     }
+     echo gen_date($DBLANG);
+ break;
+
  case 'misstags':
      $misstags = get_misstags($dbhandle, $lang);
 
@@ -211,16 +268,21 @@ TRANSLATORS_HEAD;
      echo '<tr><th>File status type</th><th>Number of files</th><th>Percent of files</th><th>Size of files (kB)</th><th>Percent of size</th></tr>';
 
      foreach ($TRANSLATION_STATUSES as $status => $description) {
+         // A status kept out of the total has no meaningful share of it.
+         $offTotal = in_array($status, $TRANSLATION_STATUSES_OFF_TOTAL);
+
          echo
             '<tr>',
             '<td>', $description, '</td>',
             '<td>', $stats[$status]['total'] ?? 0, '</td>',
             '<td>',
-            sprintf('%.2f%%', 100 * (($stats[$status]['total'] ?? 0) / $stats['total']['total'])),
+            $offTotal ? 'n/a'
+                : sprintf('%.2f%%', 100 * (($stats[$status]['total'] ?? 0) / $stats['total']['total'])),
             '</td>',
             '<td>', $stats[$status]['size'] ?? 0, '</td>',
             '<td>',
-            sprintf('%.2f%%', 100 * (($stats[$status]['size'] ?? 0) / $stats['total']['size'])),
+            $offTotal ? 'n/a'
+                : sprintf('%.2f%%', 100 * (($stats[$status]['size'] ?? 0) / $stats['total']['size'])),
             '</td>',
             '</tr>';
      }


### PR DESCRIPTION
Front end for the two statuses added in php/doc-base#334.

Once that one is deployed, files carrying the new statuses land in the `files` table and count in the denominator of `get_lang_stats()`, but show up in no row of the file summary. The percentages then stop adding up to 100, with nothing on the page saying why. Until it is deployed this PR is inert: the queries just return nothing.

It adds two pages, `p=brokenfiles` and `p=donottranslate`, built on the same shape as the existing `misstags` and `oldfiles` pages, plus their menu entries and the two statuses in `$TRANSLATION_STATUSES`.

Files marked do not translate are listed but left out of the completion totals, to match `scripts/revcheck.php` and `genrevdb.php` in doc-base: a translation should not see its rate drop for files it is not expected to have. Their share of a total they are not part of shows as `n/a`. Other statuses are displayed as before. If that is the wrong call on this side, it is a small change to make.

Checked locally with the built-in server, against a database built from doc-fr and doc-ru.

The file summary gains the two rows:

<img width="1180" height="655" alt="summary-ru" src="https://github.com/user-attachments/assets/91409e26-fd1f-48a5-bb6e-647ec73e8108" />

Broken XML lists `chmonly/search.xml` with its parse error:

<img width="1180" height="655" alt="broken-ru" src="https://github.com/user-attachments/assets/7ea4014d-f81e-4d7e-b4c8-81b699ca5ebc" />

Do not translate lists the marked files:

<img width="1180" height="655" alt="dnt-fr" src="https://github.com/user-attachments/assets/fcf85af2-cb12-437f-a34d-2258a508cc5a" />
