### PR TITLE
Add Cache-Control header to revcheck.php for improved caching

### DIFF
--- a/www/revcheck.php
+++ b/www/revcheck.php
@@ -52,6 +52,7 @@ if ($lang !== 'en' && is_null($lang_intro)) {
 }
 
 site_header();
+header('Cache-Control: public, max-age=3600');
 switch($tool) {
  case 'translators':
     $translators = get_translators($dbhandle, $lang);


### PR DESCRIPTION
Caching can result in retrieving outdated information; I'm not sure if we should set different time values based on `$tool`.

https://doc.php.net/revcheck.php?p=files&lang=zh